### PR TITLE
Fixing double compression issue when the response is already compressed

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 1.0.24 - March 22 2022
+* Fix for avoiding double compression
+
 ### 1.0.23 - July 13 2021
 * Reference component update
 

--- a/src/Owin.Compression.Standard/AssemblyInfo.fs
+++ b/src/Owin.Compression.Standard/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("Owin.Compression.Standard")>]
 [<assembly: AssemblyProductAttribute("Owin.Compression")>]
 [<assembly: AssemblyDescriptionAttribute("Compression (Deflate / GZip) module for Microsoft OWIN Selfhost filesystem pipeline.")>]
-[<assembly: AssemblyVersionAttribute("1.0.23")>]
-[<assembly: AssemblyFileVersionAttribute("1.0.23")>]
+[<assembly: AssemblyVersionAttribute("1.0.24")>]
+[<assembly: AssemblyFileVersionAttribute("1.0.24")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "Owin.Compression.Standard"
     let [<Literal>] AssemblyProduct = "Owin.Compression"
     let [<Literal>] AssemblyDescription = "Compression (Deflate / GZip) module for Microsoft OWIN Selfhost filesystem pipeline."
-    let [<Literal>] AssemblyVersion = "1.0.23"
-    let [<Literal>] AssemblyFileVersion = "1.0.23"
+    let [<Literal>] AssemblyVersion = "1.0.24"
+    let [<Literal>] AssemblyFileVersion = "1.0.24"

--- a/src/Owin.Compression.Standard/CompressionModule.fs
+++ b/src/Owin.Compression.Standard/CompressionModule.fs
@@ -241,8 +241,10 @@ module OwinCompression =
                         }
 
                     if usecompress && checkNoValidETag(context.Response.Body) then
+                        let isAlreadyCompressed = not(String.IsNullOrWhiteSpace(context.Response.Headers.["Content-Encoding"]));
                         match (not context.Response.Body.CanSeek) || (not context.Response.Body.CanRead) 
-                              || context.Response.Body.Length < settings.MinimumSizeToCompress with
+                              || context.Response.Body.Length < settings.MinimumSizeToCompress
+                              || isAlreadyCompressed with
                         | true -> 
                             if context.Response.Body.CanSeek then
                                 context.Response.Body.Seek(0L, SeekOrigin.Begin) |> ignore

--- a/src/Owin.Compression/AssemblyInfo.fs
+++ b/src/Owin.Compression/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("Owin.Compression")>]
 [<assembly: AssemblyProductAttribute("Owin.Compression")>]
 [<assembly: AssemblyDescriptionAttribute("Compression (Deflate / GZip) module for Microsoft OWIN Selfhost filesystem pipeline.")>]
-[<assembly: AssemblyVersionAttribute("1.0.23")>]
-[<assembly: AssemblyFileVersionAttribute("1.0.23")>]
+[<assembly: AssemblyVersionAttribute("1.0.24")>]
+[<assembly: AssemblyFileVersionAttribute("1.0.24")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "Owin.Compression"
     let [<Literal>] AssemblyProduct = "Owin.Compression"
     let [<Literal>] AssemblyDescription = "Compression (Deflate / GZip) module for Microsoft OWIN Selfhost filesystem pipeline."
-    let [<Literal>] AssemblyVersion = "1.0.23"
-    let [<Literal>] AssemblyFileVersion = "1.0.23"
+    let [<Literal>] AssemblyVersion = "1.0.24"
+    let [<Literal>] AssemblyFileVersion = "1.0.24"

--- a/src/Owin.Compression/CompressionModule.fs
+++ b/src/Owin.Compression/CompressionModule.fs
@@ -232,8 +232,10 @@ module OwinCompression =
                         }
 
                     if usecompress && checkNoValidETag(context.Response.Body) then
+                        let isAlreadyCompressed = not(String.IsNullOrWhiteSpace(context.Response.Headers.["Content-Encoding"]));
                         match (not context.Response.Body.CanSeek) || (not context.Response.Body.CanRead) 
-                              || context.Response.Body.Length < settings.MinimumSizeToCompress with
+                              || context.Response.Body.Length < settings.MinimumSizeToCompress
+                              || isAlreadyCompressed with
                         | true -> 
                             if context.Response.Body.CanSeek then
                                 context.Response.Body.Seek(0L, SeekOrigin.Begin) |> ignore


### PR DESCRIPTION
Fixing double compression issue when the response is already compressed.
Bumping up the library version.